### PR TITLE
Preserve ampersand tokenization

### DIFF
--- a/syntaxes/bemSupport.tmLanguage.json
+++ b/syntaxes/bemSupport.tmLanguage.json
@@ -6,17 +6,19 @@
 		"bem_support": {
 			"patterns": [
         {
-          "match": "&__\\S*",
+          "match": "(&)(__\\S*)",
           "name": "entity.other.attribute-name.class.css",
           "captures": {
-            "0": { "name": "bem.support.element.scss" }
+            "1": { "name": "entity.name.tag.reference.scss" },
+            "2": { "name": "bem.support.element.scss" }
           }
         },
         {
-          "match": "&--\\S*",
+          "match": "(&)(--\\S*)",
           "name": "entity.other.attribute-name.class.css",
           "captures": {
-            "0": { "name": "bem.support.modifier.scss" }
+            "1": { "name": "entity.name.tag.reference.scss" },
+            "2": { "name": "bem.support.modifier.scss" }
           }
         }
       ]

--- a/syntaxes/bemSupport.tmLanguage.json
+++ b/syntaxes/bemSupport.tmLanguage.json
@@ -6,7 +6,7 @@
 		"bem_support": {
 			"patterns": [
         {
-          "match": "(&)(__\\S*)",
+          "match": "(&)(__[-a-zA-Z_0-9]*)",
           "name": "entity.other.attribute-name.class.css",
           "captures": {
             "1": { "name": "entity.name.tag.reference.scss" },
@@ -14,7 +14,7 @@
           }
         },
         {
-          "match": "(&)(--\\S*)",
+          "match": "(&)(--[-a-zA-Z_0-9]*)",
           "name": "entity.other.attribute-name.class.css",
           "captures": {
             "1": { "name": "entity.name.tag.reference.scss" },


### PR DESCRIPTION
Thanks so much for this extension! I was about to try and do it myself and then I found this on the marketplace.

I just have one tiny suggestion — this PR preserves the original tokenization of the ampersand character (as `entity.name.tag.reference.scss`) so that the ampersand color can be kept consistent throughout an SCSS file.

Here's a before and after GIF:

![Before and after](https://media.giphy.com/media/MEj1dsKvNnWrHi1vSx/giphy.gif)

EDIT: After further testing, I also replaced the `\S` in the regex with `[-a-zA-Z_0-9]` to capture only valid CSS class characters. This prevents things like commas, pseudo-selectors and the like from being lumped in with the class name token.

Here's another before and after:

![Before and after](https://media.giphy.com/media/kG2YYy2wMkoOX9QK1P/giphy.gif)